### PR TITLE
refactor: update WOD type handling and improve error handling in admin page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 type WodFormData = {
   date: string;
   title: string;
-  type: string[];
+  type: ("cardio" | "gymnastics" | "strength")[];
   description: string;
   level: string;
 };
@@ -82,7 +82,7 @@ export default function AdminPage() {
     setFormData((prev) => ({
       ...prev,
       type: checked
-        ? [...prev.type, value]
+        ? [...prev.type, value as "cardio" | "gymnastics" | "strength"]
         : prev.type.filter((t) => t !== value),
     }));
   };
@@ -98,6 +98,11 @@ export default function AdminPage() {
       const month = (dateObj.getMonth() + 1).toString().padStart(2, "0");
       const day = dateObj.getDate().toString().padStart(2, "0");
       const formattedDate = `${year}${month}${day}`;
+
+      // type 배열이 비어있는지 확인
+      if (formData.type.length === 0) {
+        throw new Error("최소 하나 이상의 타입을 선택해주세요.");
+      }
 
       const { error } = await supabase.from("wods").insert([
         {

--- a/src/app/wods/page.tsx
+++ b/src/app/wods/page.tsx
@@ -64,21 +64,25 @@ export default function WodsPage() {
 
       const wodMap: WodMap = {};
       allData.forEach((wod: any) => {
+        console.log("Processing WOD for date:", wod.date);
         console.log("Raw WOD data:", wod);
+
         // type이 문자열인 경우 쉼표로 분리하여 배열로 변환
-        const types =
-          typeof wod.type === "string"
-            ? wod.type
+        const types = Array.isArray(wod.type)
+          ? wod.type
+          : typeof wod.type === "string"
+          ? wod.type.startsWith("[")
+            ? JSON.parse(wod.type)
+            : wod.type
                 .split(",")
                 .map(
                   (t: string) =>
                     t.trim() as "cardio" | "gymnastics" | "strength"
                 )
-            : Array.isArray(wod.type)
-            ? wod.type
-            : [wod.type];
+          : [wod.type];
 
         console.log("Processed types:", types);
+        console.log("Date being used as key:", wod.date);
 
         wodMap[wod.date] = {
           title: wod.title,
@@ -89,6 +93,7 @@ export default function WodsPage() {
       });
 
       console.log("Final WOD map:", wodMap);
+      console.log("Available dates in map:", Object.keys(wodMap));
       setWods(wodMap);
     } catch (error: any) {
       console.error("Error fetching WODs:", {

--- a/src/components/WodCard.tsx
+++ b/src/components/WodCard.tsx
@@ -28,22 +28,16 @@ export default function WodCard({
   return (
     <div className="bg-white shadow-md rounded-lg p-4">
       <div className="flex items-center mb-2">
-        <div className="flex items-center mr-2">
-          {type.map((t, index) => (
-            <span key={t} className="text-gray-500 text-sm">
-              {typeIconMap[t]}
-              {index < type.length - 1 && <span className="mx-1">+</span>}
-            </span>
-          ))}
-        </div>
-        <div className="flex gap-1">
+        <div className="flex items-center gap-2">
           {type.map((t) => (
-            <span
-              key={t}
-              className={`px-2 py-1 rounded-full text-xs text-white ${typeColorMap[t]}`}
-            >
-              {t}
-            </span>
+            <div key={t} className="flex items-center">
+              <span className="text-xl mr-1">{typeIconMap[t]}</span>
+              <span
+                className={`px-2 py-1 rounded-full text-xs text-white ${typeColorMap[t]}`}
+              >
+                {t}
+              </span>
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
와드 타입

5/19의 경우: type: 'cardio, strength' (일반 문자열)
5/20의 경우: type: '["cardio","strength"]' (JSON 문자열)
5/20의 데이터는 JSON 문자열 형태로 저장되어 있어서, 현재 코드로는 제대로 파싱되지 않고 있습니다. 이 문제를 해결하기 위해 코드를 수정하겠습니다

수정된 코드는 다음과 같이 작동합니다:
wod.type이 배열이면 그대로 사용
문자열인 경우:
[로 시작하면 JSON 문자열로 간주하고 JSON.parse()로 파싱
그렇지 않으면 기존처럼 쉼표로 분리하여 처리
그 외의 경우는 단일 값을 배열로 변환
이제 5/29와 5/30의 WOD 타입도 제대로 표시될 것입니다. 변경사항을 적용한 후 다시 확인해보시기 바랍니다.
추가로, 데이터베이스에 새로운 WOD를 추가할 때는 일관된 형식으로 저장하는 것이 좋을 것 같습니다. 두 가지 방법 중 하나를 선택하시면 됩니다:
모든 WOD의 type을 "cardio, strength" 형식으로 저장
모든 WOD의 type을 '["cardio","strength"]' 형식으로 저장